### PR TITLE
feat(release): GitHub Packages publish + full Release Please changelog sections

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -55,8 +55,8 @@ This is a Ruby CLI gem project called "vergissberlin" that provides a useless to
 ### Release Process
 - Release Please opens a release PR from conventional commits
 - Merging the release PR creates a GitHub release/tag
-- Publish job pushes the gem to RubyGems
-- Requires `RUBYGEMS_API_KEY` secret
+- Publish job pushes the gem to RubyGems.org and GitHub Packages
+- Requires `RUBYGEMS_API_KEY` secret (RubyGems); GitHub Packages uses `GITHUB_TOKEN`
 
 ## Dependencies
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  packages: write
   id-token: write
 
 jobs:
@@ -27,6 +28,9 @@ jobs:
     needs: release-please
     if: needs.release-please.outputs.release_created == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
 
     steps:
       - uses: actions/checkout@v4
@@ -39,16 +43,24 @@ jobs:
           ruby-version: "3.4"
           bundler-cache: true
 
-      - name: Configure RubyGems credentials
+      - name: Configure gem credentials
         run: |
           mkdir -p ~/.gem
           cat <<EOF > ~/.gem/credentials
           ---
           :rubygems_api_key: ${{ secrets.RUBYGEMS_API_KEY }}
+          :github: Bearer ${{ secrets.GITHUB_TOKEN }}
           EOF
           chmod 0600 ~/.gem/credentials
 
-      - name: Build and publish gem
+      - name: Build gem
+        run: gem build vergissberlin.gemspec
+
+      - name: Publish to RubyGems.org
+        run: gem push vergissberlin-*.gem
+
+      - name: Publish to GitHub Packages
         run: |
-          gem build vergissberlin.gemspec
-          gem push vergissberlin-*.gem
+          gem push --key github \
+            --host "https://rubygems.pkg.github.com/${{ github.repository_owner }}" \
+            vergissberlin-*.gem

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,9 +97,12 @@ Releases are automated:
 1. Land conventional commits on `main`
 2. Release Please opens/updates a release PR (changelog + version bump)
 3. Merging that PR creates the GitHub release/tag
-4. `release.yml` publishes the gem to RubyGems using `RUBYGEMS_API_KEY`
+4. `release.yml` publishes the gem to **RubyGems.org** (`RUBYGEMS_API_KEY`)
+   and **GitHub Packages** (`GITHUB_TOKEN` + `packages: write`)
 
-Do not create release tags by hand unless explicitly asked.
+All Conventional Commit types are visible changelog sections in
+`release-please-config.json` (so non-`feat`/`fix` commits can still open a
+release PR). Do not create release tags by hand unless explicitly asked.
 
 ## Communication
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,9 +42,25 @@ Version bumps, `CHANGELOG.md`, and GitHub releases are handled by [Release Pleas
 1. Land changes on `main` using Conventional Commits
 2. Release Please opens or updates a release PR
 3. Merge the release PR to cut a tagged GitHub release
-4. `.github/workflows/release.yml` builds and pushes the gem to RubyGems
+4. `.github/workflows/release.yml` builds and pushes the gem to
+   **RubyGems.org** and **GitHub Packages**
 
 You usually do **not** edit `lib/vergissberlin/version.rb` by hand.
+
+### Changelog categories
+
+`release-please-config.json` lists every common Conventional Commit type as a
+visible changelog section (`feat`, `fix`, `perf`, `deps`, `revert`, `docs`,
+`style`, `chore`, `refactor`, `test`, `build`, `ci`). Non-hidden sections are
+included in release notes and can open a release PR.
+
+Version bumps still follow SemVer via Release Please:
+
+| Commit type | Effect (pre-1.0 with current config) |
+| --- | --- |
+| `feat` | patch (`bump-patch-for-minor-pre-major`) |
+| `fix` / other visible types | patch |
+| breaking (`!` / `BREAKING CHANGE`) | minor (`bump-minor-pre-major`) |
 
 ### Conventional Commits
 
@@ -58,7 +74,8 @@ All commit messages must be written in English.
 [optional footer(s)]
 ```
 
-Common types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `chore`.
+Common types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`,
+`chore`, `build`, `ci`, `deps`.
 
 Examples:
 
@@ -78,7 +95,8 @@ BREAKING CHANGE: The CLI now requires subcommands instead of flags"
 
 ### RubyGems API Key (CI)
 
-For automatic publishing, add a repository secret named `RUBYGEMS_API_KEY`:
+For automatic publishing to RubyGems.org, add a repository secret named
+`RUBYGEMS_API_KEY`:
 
 1. Create an API key on [RubyGems.org](https://rubygems.org)
 2. In the GitHub repo: Settings → Secrets and variables → Actions
@@ -86,11 +104,30 @@ For automatic publishing, add a repository secret named `RUBYGEMS_API_KEY`:
 
 Never commit API keys. Rotate them regularly and limit permissions.
 
+### GitHub Packages (CI)
+
+Publishing to
+[GitHub Packages](https://github.com/vergissberlin/vergissberlin-cli/packages)
+uses the workflow `GITHUB_TOKEN` (`packages: write`). No extra secret is
+required. The gemspec sets `metadata["github_repo"]` so the package links to
+this repository.
+
+First publish is private by default; set package visibility to public in the
+GitHub UI if needed.
+
 ### Manual publish (fallback)
 
 ```bash
 gem build vergissberlin.gemspec
+
+# RubyGems.org
 gem push vergissberlin-*.gem
+
+# GitHub Packages (classic PAT with write:packages)
+# ~/.gem/credentials should contain: :github: Bearer TOKEN
+gem push --key github \
+  --host https://rubygems.pkg.github.com/vergissberlin \
+  vergissberlin-*.gem
 ```
 
 ## Code Style

--- a/README.md
+++ b/README.md
@@ -11,22 +11,30 @@ Some hot useless stuff! Trust me, there is no functionality.
 
 ### For End Users
 
-Add this line to your application's Gemfile:
+**RubyGems.org** (default):
 
 ```ruby
 gem "vergissberlin"
 ```
 
-And then execute:
-
 ```bash
 bundle install
+# or
+gem install vergissberlin
 ```
 
-Or install it yourself as:
+**GitHub Packages** ([packages](https://github.com/vergissberlin/vergissberlin-cli/packages)):
+
+```ruby
+source "https://rubygems.pkg.github.com/vergissberlin" do
+  gem "vergissberlin"
+end
+```
+
+Authenticate Bundler (classic PAT with `read:packages`):
 
 ```bash
-gem install vergissberlin
+bundle config https://rubygems.pkg.github.com/vergissberlin USERNAME:TOKEN
 ```
 
 ### For Developers
@@ -65,7 +73,9 @@ Releases are automated with [Release Please](https://github.com/googleapis/relea
 1. Merge conventional commits into `main`
 2. Release Please opens (or updates) a release PR with changelog + version bump
 3. Merging that PR creates a GitHub release/tag
-4. The release workflow publishes the gem to RubyGems
+4. The release workflow publishes the gem to **RubyGems.org** and **GitHub Packages**
+
+All Conventional Commit types (`feat`, `fix`, `docs`, `refactor`, `chore`, …) appear in the changelog and can open a release PR. Version bumps still follow SemVer (`feat` / `fix` / `perf` / breaking).
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for details.
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -9,7 +9,21 @@
       "bump-patch-for-minor-pre-major": true,
       "include-component-in-tag": false,
       "include-v-in-tag": true,
-      "version-file": "lib/vergissberlin/version.rb"
+      "version-file": "lib/vergissberlin/version.rb",
+      "changelog-sections": [
+        { "type": "feat", "section": "Features" },
+        { "type": "fix", "section": "Bug Fixes" },
+        { "type": "perf", "section": "Performance Improvements" },
+        { "type": "deps", "section": "Dependencies" },
+        { "type": "revert", "section": "Reverts" },
+        { "type": "docs", "section": "Documentation" },
+        { "type": "style", "section": "Styles" },
+        { "type": "chore", "section": "Miscellaneous Chores" },
+        { "type": "refactor", "section": "Code Refactoring" },
+        { "type": "test", "section": "Tests" },
+        { "type": "build", "section": "Build System" },
+        { "type": "ci", "section": "Continuous Integration" }
+      ]
     }
   }
 }

--- a/vergissberlin.gemspec
+++ b/vergissberlin.gemspec
@@ -19,6 +19,9 @@ Gem::Specification.new do |spec|
   spec.metadata['source_code_uri'] = spec.homepage
   spec.metadata['changelog_uri'] = "#{spec.homepage}/blob/main/CHANGELOG.md"
   spec.metadata['rubygems_mfa_required'] = 'true'
+  # Link GitHub Packages gem to this repository (name may differ from gem).
+  spec.metadata['github_repo'] =
+    'ssh://github.com/vergissberlin/vergissberlin-cli'
 
   spec.files = Dir.chdir(__dir__) do
     `git ls-files -z`.split("\x0").reject do |f|


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Expand Release Please `changelog-sections` so **all** Conventional Commit types (`feat`, `fix`, `docs`, `refactor`, `chore`, `ci`, …) are visible and can open a release PR (pending changes since `v0.1.4` including #9 will be covered once this lands on `main`).
- Dual-publish each release gem to **RubyGems.org** and **GitHub Packages** (`https://rubygems.pkg.github.com/vergissberlin`).
- Link the package to this repo via gemspec `metadata["github_repo"]`.
- Document install/publish for both registries in README and CONTRIBUTING.

## After merge

1. Release Please should open/update a release PR for commits since `v0.1.4`.
2. Merging that release PR tags the release and runs publish to both registries.
3. First GitHub Packages publish may be **private** — set visibility to public in the [packages UI](https://github.com/vergissberlin/vergissberlin-cli/packages) if desired.

## Test plan

- [x] `bundle exec rake test` (10 runs, 100% coverage)
- [x] `gem build` includes `github_repo` metadata
- [x] `release-please-config.json` validates as JSON
- [ ] CI green on this PR
- [ ] After merge: Release Please opens a release PR
- [ ] After release merge: gem appears on RubyGems and GitHub Packages

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a32a39a5-9df7-425f-b523-cfc2b226c288"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a32a39a5-9df7-425f-b523-cfc2b226c288"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

