### PR TITLE
test(cli): cover -v/--version installed version output

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Ruby 3.2+ is required.
 
 ```bash
 vergissberlin          # print the useless banner
-vergissberlin --version
+vergissberlin --version  # print installed version (also -v)
 vergissberlin --help
 ```
 

--- a/lib/vergissberlin/cli.rb
+++ b/lib/vergissberlin/cli.rb
@@ -72,7 +72,9 @@ module Vergissberlin
     def build_parser(options)
       OptionParser.new do |opts|
         opts.banner = 'Usage: vergissberlin [options]'
-        opts.on('-v', '--version', 'Show version') { options[:version] = true }
+        opts.on('-v', '--version', 'Show installed version') do
+          options[:version] = true
+        end
         opts.on('-h', '--help', 'Show help') { options[:help] = true }
       end
     end

--- a/test/bin_cli_test.rb
+++ b/test/bin_cli_test.rb
@@ -11,7 +11,15 @@ class BinCliTest < Minitest::Test
       RbConfig.ruby, BIN_PATH, '--version'
     )
     assert status.success?, "Process failed: #{stderr}"
-    assert_match(/\A\d+\.\d+\.\d+\n\z/, stdout)
+    assert_equal "#{Vergissberlin::VERSION}\n", stdout
+  end
+
+  def test_cli_short_version_flag
+    stdout, stderr, status = Open3.capture3(
+      RbConfig.ruby, BIN_PATH, '-v'
+    )
+    assert status.success?, "Process failed: #{stderr}"
+    assert_equal "#{Vergissberlin::VERSION}\n", stdout
   end
 
   def test_cli_help_flag

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -9,7 +9,15 @@ class CliTest < Minitest::Test
     status = Vergissberlin::CLI.run(['--version'], out: out)
 
     assert_equal 0, status
-    assert_match(/\A\d+\.\d+\.\d+\n\z/, out.string)
+    assert_equal "#{Vergissberlin::VERSION}\n", out.string
+  end
+
+  def test_short_version_flag
+    out = StringIO.new
+    status = Vergissberlin::CLI.run(['-v'], out: out)
+
+    assert_equal 0, status
+    assert_equal "#{Vergissberlin::VERSION}\n", out.string
   end
 
   def test_help_flag


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`--version` / `-v` already print the installed gem version (`Vergissberlin::VERSION`). This PR locks that behavior in with explicit short-flag coverage and clearer docs/help text.

## Changes

- Assert `--version` and `-v` both print exactly `Vergissberlin::VERSION`
- Cover `-v` in CLI unit and bin integration tests
- Clarify help text and README usage for the version flags

## Test plan

- [x] `bundle exec rake test`
- [x] `bundle exec vergissberlin --version`
- [x] `bundle exec vergissberlin -v`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5f5a8e2d-824b-432c-a6ab-5f408d16735a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5f5a8e2d-824b-432c-a6ab-5f408d16735a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

