### PR TITLE
feat(cli): fix THATS COOL banner and add rainbow colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,10 +52,14 @@ Ruby 3.2+ is required.
 ## Usage
 
 ```bash
-vergissberlin          # print the useless banner
+vergissberlin          # print the rainbow "THATS COOL" banner
 vergissberlin --version  # print installed version (also -v)
 vergissberlin --help
 ```
+
+The default banner uses a diagonal rainbow (ANSI truecolor) when stdout is a
+TTY. Set `NO_COLOR=1` to disable colors, or `FORCE_COLOR=1` to force them
+(overrides `NO_COLOR`). Use `FORCE_COLOR=0` to disable colors explicitly.
 
 ## Development
 

--- a/lib/vergissberlin/cli.rb
+++ b/lib/vergissberlin/cli.rb
@@ -6,18 +6,19 @@ require 'vergissberlin/version'
 module Vergissberlin
   # Command-line interface for the vergissberlin gem.
   class CLI
-    BANNER = [
-      '',
-      '',
-      '  _______ _    _       _______ _____    _____ ____   ____  _',
-      ' |__   __| |  | |   /\\|__   __/ ____|  / ____/ __ \\ / __ \\| |',
-      '    | |  | |__| |  /  \\  | | | (___   | |   | |  | | |  | | |',
-      '    | |  |  __  | / /\\ \\ | |  \\___ \\  | |   | |  | | |  | | |',
-      '    | |  | |  | |/ ____ \\| |  ____) | | |___| |__| | |__| | |____',
-      '    |_|  |_|  |_/_/    \\_\\_| |_____/   \\_____\\____/ \\____/|______|',
-      '',
-      ''
-    ].join("\n").freeze
+    # Properly aligned figlet "big" banner for "THATS COOL".
+    BANNER_LINES = [
+      ' _______ _    _       _______ _____    _____ ____   ____  _      ',
+      '|__   __| |  | |   /\\|__   __/ ____|  / ____/ __ \\ / __ \\| |     ',
+      '   | |  | |__| |  /  \\  | | | (___   | |   | |  | | |  | | |     ',
+      '   | |  |  __  | / /\\ \\ | |  \\___ \\  | |   | |  | | |  | | |     ',
+      '   | |  | |  | |/ ____ \\| |  ____) | | |___| |__| | |__| | |____ ',
+      '   |_|  |_|  |_/_/    \\_\\_| |_____/   \\_____\\____/ \\____/|______|'
+    ].freeze
+
+    BANNER = (['', ''] + BANNER_LINES + ['', '']).join("\n").freeze
+
+    RESET = "\e[0m"
 
     def self.run(argv = ARGV, out: $stdout, err: $stderr)
       new(argv, out: out, err: err).run
@@ -43,7 +44,7 @@ module Vergissberlin
       return show_help if options[:help]
       return show_version if options[:version]
 
-      @out.print BANNER
+      @out.print render_banner
       0
     end
 
@@ -77,6 +78,45 @@ module Vergissberlin
         end
         opts.on('-h', '--help', 'Show help') { options[:help] = true }
       end
+    end
+
+    def render_banner
+      return BANNER unless colorize?
+
+      colored = BANNER_LINES.map.with_index do |line, row|
+        rainbow_line(line, row)
+      end
+      "\n\n#{colored.join("\n")}\n\n"
+    end
+
+    def colorize?
+      force = ENV['FORCE_COLOR']
+      return false if force == '0'
+      return true if force && !force.empty?
+
+      return false if ENV['NO_COLOR']
+
+      clicolor = ENV['CLICOLOR_FORCE']
+      return true if clicolor && !clicolor.empty? && clicolor != '0'
+
+      @out.respond_to?(:tty?) && @out.tty?
+    end
+
+    # Lolcat-style diagonal rainbow via ANSI truecolor.
+    def rainbow_line(line, row)
+      line.chars.map.with_index do |char, col|
+        r, g, b = rainbow_rgb(row + col)
+        "\e[38;2;#{r};#{g};#{b}m#{char}"
+      end.join + RESET
+    end
+
+    def rainbow_rgb(index)
+      freq = 0.15
+      [
+        (Math.sin(freq * index) * 127 + 128).round,
+        (Math.sin(freq * index + 2 * Math::PI / 3) * 127 + 128).round,
+        (Math.sin(freq * index + 4 * Math::PI / 3) * 127 + 128).round
+      ]
     end
   end
 end

--- a/lib/vergissberlin/cli.rb
+++ b/lib/vergissberlin/cli.rb
@@ -90,15 +90,28 @@ module Vergissberlin
     end
 
     def colorize?
-      force = ENV['FORCE_COLOR']
-      return false if force == '0'
-      return true if force && !force.empty?
-
+      forced = force_color_setting
+      return forced unless forced.nil?
       return false if ENV['NO_COLOR']
+      return true if env_flag_on?('CLICOLOR_FORCE')
 
-      clicolor = ENV['CLICOLOR_FORCE']
-      return true if clicolor && !clicolor.empty? && clicolor != '0'
+      tty_out?
+    end
 
+    # nil = unset, true/false = explicit force on/off
+    def force_color_setting
+      force = ENV['FORCE_COLOR']
+      return nil if force.nil? || force.empty?
+
+      force != '0'
+    end
+
+    def env_flag_on?(name)
+      value = ENV[name]
+      !(value.nil? || value.empty? || value == '0')
+    end
+
+    def tty_out?
       @out.respond_to?(:tty?) && @out.tty?
     end
 
@@ -111,12 +124,15 @@ module Vergissberlin
     end
 
     def rainbow_rgb(index)
-      freq = 0.15
       [
-        (Math.sin(freq * index) * 127 + 128).round,
-        (Math.sin(freq * index + 2 * Math::PI / 3) * 127 + 128).round,
-        (Math.sin(freq * index + 4 * Math::PI / 3) * 127 + 128).round
+        wave(index, 0),
+        wave(index, 2 * Math::PI / 3),
+        wave(index, 4 * Math::PI / 3)
       ]
+    end
+
+    def wave(index, phase)
+      (Math.sin(0.15 * index + phase) * 127 + 128).round
     end
   end
 end

--- a/test/bin_cli_test.rb
+++ b/test/bin_cli_test.rb
@@ -31,8 +31,12 @@ class BinCliTest < Minitest::Test
   end
 
   def test_cli_default_banner
-    stdout, stderr, status = Open3.capture3(RbConfig.ruby, BIN_PATH)
+    stdout, stderr, status = Open3.capture3(
+      { 'NO_COLOR' => '1', 'FORCE_COLOR' => '0' },
+      RbConfig.ruby, BIN_PATH
+    )
     assert status.success?, "Process failed: #{stderr}"
     assert_includes stdout, '_______'
+    refute_includes stdout, "\e["
   end
 end

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -34,6 +34,48 @@ class CliTest < Minitest::Test
 
     assert_equal 0, status
     assert_includes out.string, '_______'
+    assert_includes out.string, '|_____/'
+    refute_includes out.string, "\e["
+  end
+
+  def test_banner_lines_are_aligned
+    widths = Vergissberlin::CLI::BANNER_LINES.map(&:length)
+
+    assert_equal 1, widths.uniq.size, 'banner lines must share one width'
+    assert(widths.first >= 60)
+  end
+
+  def test_rainbow_banner_when_forced
+    out = StringIO.new
+    with_env('FORCE_COLOR' => '1', 'NO_COLOR' => nil) do
+      status = Vergissberlin::CLI.run([], out: out)
+
+      assert_equal 0, status
+      assert_includes out.string, "\e[38;2;"
+      assert_includes out.string, "\e[0m"
+      plain = out.string.gsub(/\e\[[0-9;]*m/, '')
+      assert_includes plain, '_______'
+    end
+  end
+
+  def test_no_color_disables_rainbow
+    out = StringIO.new
+    with_env('FORCE_COLOR' => nil, 'NO_COLOR' => '1') do
+      status = Vergissberlin::CLI.run([], out: out)
+
+      assert_equal 0, status
+      refute_includes out.string, "\e["
+    end
+  end
+
+  def test_force_color_zero_disables_rainbow
+    out = StringIO.new
+    with_env('FORCE_COLOR' => '0', 'NO_COLOR' => nil) do
+      status = Vergissberlin::CLI.run([], out: out)
+
+      assert_equal 0, status
+      refute_includes out.string, "\e["
+    end
   end
 
   def test_invalid_option
@@ -44,5 +86,27 @@ class CliTest < Minitest::Test
     assert_equal 1, status
     assert_includes err.string, 'invalid option'
     assert_includes err.string, 'Usage:'
+  end
+
+  private
+
+  def with_env(vars)
+    previous = vars.keys.to_h { |key| [key, ENV[key]] }
+    vars.each do |key, value|
+      if value.nil?
+        ENV.delete(key)
+      else
+        ENV[key] = value
+      end
+    end
+    yield
+  ensure
+    previous.each do |key, value|
+      if value.nil?
+        ENV.delete(key)
+      else
+        ENV[key] = value
+      end
+    end
   end
 end

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -78,6 +78,20 @@ class CliTest < Minitest::Test
     end
   end
 
+  def test_clicolor_force_enables_rainbow
+    out = StringIO.new
+    with_env(
+      'FORCE_COLOR' => nil,
+      'NO_COLOR' => nil,
+      'CLICOLOR_FORCE' => '1'
+    ) do
+      status = Vergissberlin::CLI.run([], out: out)
+
+      assert_equal 0, status
+      assert_includes out.string, "\e[38;2;"
+    end
+  end
+
   def test_invalid_option
     out = StringIO.new
     err = StringIO.new
@@ -92,21 +106,15 @@ class CliTest < Minitest::Test
 
   def with_env(vars)
     previous = vars.keys.to_h { |key| [key, ENV[key]] }
-    vars.each do |key, value|
-      if value.nil?
-        ENV.delete(key)
-      else
-        ENV[key] = value
-      end
-    end
+    apply_env(vars)
     yield
   ensure
-    previous.each do |key, value|
-      if value.nil?
-        ENV.delete(key)
-      else
-        ENV[key] = value
-      end
+    apply_env(previous)
+  end
+
+  def apply_env(vars)
+    vars.each do |key, value|
+      value.nil? ? ENV.delete(key) : ENV[key] = value
     end
   end
 end

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -92,6 +92,26 @@ class CliTest < Minitest::Test
     end
   end
 
+  def test_non_tty_skips_rainbow_without_env
+    out = StringIO.new
+    without_color_env do
+      status = Vergissberlin::CLI.run([], out: out)
+
+      assert_equal 0, status
+      refute_includes out.string, "\e["
+    end
+  end
+
+  def test_tty_enables_rainbow_without_env
+    out = tty_buffer
+    without_color_env do
+      status = Vergissberlin::CLI.run([], out: out)
+
+      assert_equal 0, status
+      assert_includes out.string, "\e[38;2;"
+    end
+  end
+
   def test_invalid_option
     out = StringIO.new
     err = StringIO.new
@@ -103,6 +123,23 @@ class CliTest < Minitest::Test
   end
 
   private
+
+  def without_color_env(&block)
+    with_env(
+      'FORCE_COLOR' => nil,
+      'NO_COLOR' => nil,
+      'CLICOLOR_FORCE' => nil,
+      &block
+    )
+  end
+
+  def tty_buffer
+    out = StringIO.new
+    def out.tty?
+      true
+    end
+    out
+  end
 
   def with_env(vars)
     previous = vars.keys.to_h { |key| [key, ENV[key]] }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the default `vergissberlin` ASCII banner so **THATS COOL** renders with correct figlet alignment, and paints it with a diagonal lolcat-style rainbow (ANSI truecolor) when stdout is a TTY.

## Changes

- Replace misaligned banner lines with padded figlet `big` layout (uniform width)
- Add rainbow colorization via ANSI truecolor (`38;2;r;g;b`)
- Respect `NO_COLOR`, `FORCE_COLOR=1` (overrides `NO_COLOR`), and `FORCE_COLOR=0`
- Document color env vars in README
- Cover alignment + color behavior in CLI / bin tests
- Refactor helpers to satisfy Hound Metrics (AbcSize / complexity / MethodLength)
- Add TTY / non-TTY tests so Coveralls hits 100% line + branch coverage

## Test plan

- [x] `bundle exec rake test` (100% line + branch coverage locally)
- [ ] `bundle exec vergissberlin` in a color terminal → readable rainbow banner
- [ ] `NO_COLOR=1 bundle exec vergissberlin` → plain monochrome banner
- [ ] `FORCE_COLOR=1 bundle exec vergissberlin | cat` → colors preserved through the pipe

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d2ee9434-9b81-40a0-b6b2-50760186722a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d2ee9434-9b81-40a0-b6b2-50760186722a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

