### PR TITLE
feat(cli): replace THATS COOL banner with Berlin skyline and random reason

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,8 @@ Guidance for AI coding agents working on this repository.
 | --- | --- |
 | `lib/vergissberlin.rb` | Public entrypoint |
 | `lib/vergissberlin/cli.rb` | CLI logic (`Vergissberlin::CLI`) |
+| `lib/vergissberlin/skyline.rb` | ASCII art skyline with the Fernsehturm |
+| `lib/vergissberlin/reasons.rb` | German reasons to forget Berlin (random) |
 | `lib/vergissberlin/version.rb` | `VERSION` constant (Release Please owned) |
 | `bin/vergissberlin` | Thin executable wrapper only |
 | `test/` | Minitest suite (`*_test.rb`, `test_helper.rb`) |
@@ -60,7 +62,7 @@ Prefer `bundle exec` for all Ruby tooling.
 **Do**
 
 - Follow Conventional Commits in English (`feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`, …)
-- Preserve backward-compatible CLI flags (`--help`, `--version`, default banner)
+- Preserve backward-compatible CLI flags (`--help`, `--version`, default output)
 - Update README/CONTRIBUTING when workflows or public behavior change
 - Keep the gem lightweight
 

--- a/README.md
+++ b/README.md
@@ -52,14 +52,19 @@ Ruby 3.2+ is required.
 ## Usage
 
 ```bash
-vergissberlin          # print the rainbow "THATS COOL" banner
+vergissberlin            # print the Berlin skyline + a random reason to leave
 vergissberlin --version  # print installed version (also -v)
 vergissberlin --help
 ```
 
-The default banner uses a diagonal rainbow (ANSI truecolor) when stdout is a
-TTY. Set `NO_COLOR=1` to disable colors, or `FORCE_COLOR=1` to force them
-(overrides `NO_COLOR`). Use `FORCE_COLOR=0` to disable colors explicitly.
+The default output is an ASCII art skyline of Berlin with the Fernsehturm in
+the middle, followed by a randomly picked reason for wanting to forget the
+city. The reasons are German on purpose — the gem name is a German joke.
+
+The skyline uses a diagonal rainbow (ANSI truecolor) when stdout is a TTY;
+the reason below it stays uncolored. Set `NO_COLOR=1` to disable colors, or
+`FORCE_COLOR=1` to force them (overrides `NO_COLOR`). Use `FORCE_COLOR=0` to
+disable colors explicitly.
 
 ## Development
 

--- a/lib/vergissberlin.rb
+++ b/lib/vergissberlin.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require 'vergissberlin/version'
+require 'vergissberlin/reasons'
+require 'vergissberlin/skyline'
 require 'vergissberlin/cli'
 
 module Vergissberlin

--- a/lib/vergissberlin/cli.rb
+++ b/lib/vergissberlin/cli.rb
@@ -2,32 +2,23 @@
 
 require 'optparse'
 require 'vergissberlin/version'
+require 'vergissberlin/reasons'
+require 'vergissberlin/skyline'
 
 module Vergissberlin
   # Command-line interface for the vergissberlin gem.
   class CLI
-    # Properly aligned figlet "big" banner for "THATS COOL".
-    BANNER_LINES = [
-      ' _______ _    _       _______ _____    _____ ____   ____  _      ',
-      '|__   __| |  | |   /\\|__   __/ ____|  / ____/ __ \\ / __ \\| |     ',
-      '   | |  | |__| |  /  \\  | | | (___   | |   | |  | | |  | | |     ',
-      '   | |  |  __  | / /\\ \\ | |  \\___ \\  | |   | |  | | |  | | |     ',
-      '   | |  | |  | |/ ____ \\| |  ____) | | |___| |__| | |__| | |____ ',
-      '   |_|  |_|  |_/_/    \\_\\_| |_____/   \\_____\\____/ \\____/|______|'
-    ].freeze
-
-    BANNER = (['', ''] + BANNER_LINES + ['', '']).join("\n").freeze
-
     RESET = "\e[0m"
 
-    def self.run(argv = ARGV, out: $stdout, err: $stderr)
-      new(argv, out: out, err: err).run
+    def self.run(argv = ARGV, out: $stdout, err: $stderr, random: Random.new)
+      new(argv, out: out, err: err, random: random).run
     end
 
-    def initialize(argv, out: $stdout, err: $stderr)
+    def initialize(argv, out: $stdout, err: $stderr, random: Random.new)
       @argv = argv.dup
       @out = out
       @err = err
+      @random = random
     end
 
     def run
@@ -44,7 +35,7 @@ module Vergissberlin
       return show_help if options[:help]
       return show_version if options[:version]
 
-      @out.print render_banner
+      @out.print render_skyline, render_reason
       0
     end
 
@@ -80,13 +71,17 @@ module Vergissberlin
       end
     end
 
-    def render_banner
-      return BANNER unless colorize?
-
-      colored = BANNER_LINES.map.with_index do |line, row|
-        rainbow_line(line, row)
+    def render_skyline
+      lines = Skyline::LINES
+      if colorize?
+        lines = lines.map.with_index { |line, row| rainbow_line(line, row) }
       end
-      "\n\n#{colored.join("\n")}\n\n"
+      "\n\n#{lines.join("\n")}\n\n"
+    end
+
+    # The reason stays uncolored so it reads well on any background.
+    def render_reason
+      "  #{Reasons::HEADLINE}\n  #{Reasons.sample(random: @random)}\n\n"
     end
 
     def colorize?

--- a/lib/vergissberlin/reasons.rb
+++ b/lib/vergissberlin/reasons.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Vergissberlin
+  # Randomly picked reasons for wanting to forget Berlin.
+  # The reasons stay German on purpose - the gem name is a German joke.
+  module Reasons
+    HEADLINE = 'Ein Grund, Berlin zu vergessen:'
+
+    ALL = [
+      'Ein gebrochenes Herz, das noch am Kottbusser Tor wartet.',
+      'In der U8 riecht es nach warmem Bier und alten Fehlern.',
+      'Die Straßen kleben, und niemand weiß genau, wovon.',
+      'Die Stadt kommt nie zur Ruhe, nicht mal dienstags um vier.',
+      'Zwei Jahre Wohnungssuche, null Besichtigungstermine.',
+      'Der Späti hat zu, genau dann, wenn du ihn brauchst.',
+      'Baustellen, die älter sind als deine letzte Beziehung.',
+      'Die S-Bahn fällt aus. Grund: Es ist Mittwoch.',
+      'Zwei Stunden Schlange, dann ein Kopfschütteln an der Tür.',
+      'Der Sommer dauerte elf Tage, dann kam wieder Novembergrau.',
+      'Der Amtstermin ist frei - im übernächsten Frühling.',
+      'Das Fahrrad war neu. Genau eine Nacht lang.',
+      'Alle wollen sich melden. Niemand meldet sich.',
+      'Die Miete wächst schneller als der Fernsehturm hoch ist.',
+      'Im Treppenhaus riecht es nach Silvester. Es ist Juli.',
+      'Am Ende bleibt Techno im Ohr und Sand in den Schuhen.'
+    ].freeze
+
+    # Pass a seeded Random for reproducible output.
+    def self.sample(random: Random.new)
+      ALL.sample(random: random)
+    end
+  end
+end

--- a/lib/vergissberlin/skyline.rb
+++ b/lib/vergissberlin/skyline.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Vergissberlin
+  # ASCII art of the Berlin skyline, with the Fernsehturm in the middle.
+  module Skyline
+    # Raw art. The tower axis (antenna, sphere, shaft) shares one column.
+    RAW_LINES = [
+      '                              |',
+      '                              |',
+      '                              |',
+      '                             /|\\',
+      '                           .-----.',
+      '                          / ..... \\',
+      '                         |  #####  |',
+      '                          \\ ..... /',
+      '                           \'-----\'',
+      '                             | |',
+      '                             | |',
+      '                             | |',
+      '               _             | |',
+      '             .\' \'.           | |            _____',
+      '      __    /_____\\          | |           |     |     __',
+      '     |  |   |     |  ___    /   \\   ___    | [ ] |    |  |',
+      '  ___|[]|___|  [] |_|   |__/     \\_|   |___|     |____|[]|___',
+      ' |   |  |   |     | | []|  |     | | []|   | [ ] |    |  |   |',
+      ' |[] |  |___|  [] |_| []|__|  [] |_| []|___|     |____|[]| [] |',
+      '_|___|__|___|_____|_|___|__|_____|_|___|___|_____|____|__|____|_'
+    ].freeze
+
+    WIDTH = RAW_LINES.map(&:length).max
+
+    # Padded to a single width so the diagonal rainbow stays even.
+    LINES = RAW_LINES.map { |line| line.ljust(WIDTH).freeze }.freeze
+  end
+end

--- a/test/bin_cli_test.rb
+++ b/test/bin_cli_test.rb
@@ -30,13 +30,14 @@ class BinCliTest < Minitest::Test
     assert_includes stdout, 'Usage:'
   end
 
-  def test_cli_default_banner
+  def test_cli_default_skyline_and_reason
     stdout, stderr, status = Open3.capture3(
       { 'NO_COLOR' => '1', 'FORCE_COLOR' => '0' },
       RbConfig.ruby, BIN_PATH
     )
     assert status.success?, "Process failed: #{stderr}"
-    assert_includes stdout, '_______'
+    assert_includes stdout, Vergissberlin::Skyline::LINES.last
+    assert_includes stdout, Vergissberlin::Reasons::HEADLINE
     refute_includes stdout, "\e["
   end
 end

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -28,24 +28,46 @@ class CliTest < Minitest::Test
     assert_includes out.string, 'Usage:'
   end
 
-  def test_default_banner
+  def test_default_skyline
     out = StringIO.new
     status = Vergissberlin::CLI.run([], out: out)
 
     assert_equal 0, status
-    assert_includes out.string, '_______'
-    assert_includes out.string, '|_____/'
+    Vergissberlin::Skyline::LINES.each do |line|
+      assert_includes out.string, line
+    end
     refute_includes out.string, "\e["
   end
 
-  def test_banner_lines_are_aligned
-    widths = Vergissberlin::CLI::BANNER_LINES.map(&:length)
+  def test_default_output_includes_a_random_reason
+    out = StringIO.new
+    status = Vergissberlin::CLI.run([], out: out)
 
-    assert_equal 1, widths.uniq.size, 'banner lines must share one width'
-    assert(widths.first >= 60)
+    assert_equal 0, status
+    assert_includes out.string, Vergissberlin::Reasons::HEADLINE
+    assert(Vergissberlin::Reasons::ALL.any? { |r| out.string.include?(r) })
   end
 
-  def test_rainbow_banner_when_forced
+  def test_reason_is_reproducible_for_a_seed
+    first = StringIO.new
+    second = StringIO.new
+    Vergissberlin::CLI.run([], out: first, random: Random.new(23))
+    Vergissberlin::CLI.run([], out: second, random: Random.new(23))
+
+    assert_equal first.string, second.string
+  end
+
+  def test_reason_varies_between_seeds
+    reasons = [4, 8, 15, 16, 23, 42].map do |seed|
+      out = StringIO.new
+      Vergissberlin::CLI.run([], out: out, random: Random.new(seed))
+      out.string.lines.map(&:strip).reject(&:empty?).last
+    end
+
+    assert_operator reasons.uniq.size, :>, 1
+  end
+
+  def test_rainbow_skyline_when_forced
     out = StringIO.new
     with_env('FORCE_COLOR' => '1', 'NO_COLOR' => nil) do
       status = Vergissberlin::CLI.run([], out: out)
@@ -54,7 +76,7 @@ class CliTest < Minitest::Test
       assert_includes out.string, "\e[38;2;"
       assert_includes out.string, "\e[0m"
       plain = out.string.gsub(/\e\[[0-9;]*m/, '')
-      assert_includes plain, '_______'
+      assert_includes plain, Vergissberlin::Skyline::LINES.last
     end
   end
 

--- a/test/reasons_test.rb
+++ b/test/reasons_test.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class ReasonsTest < Minitest::Test
+  ALL = Vergissberlin::Reasons::ALL
+
+  def test_sample_returns_a_known_reason
+    assert_includes ALL, Vergissberlin::Reasons.sample
+  end
+
+  def test_sample_is_reproducible_for_a_seed
+    first = Vergissberlin::Reasons.sample(random: Random.new(1979))
+    second = Vergissberlin::Reasons.sample(random: Random.new(1979))
+
+    assert_equal first, second
+  end
+
+  def test_reasons_are_unique
+    assert_equal ALL.size, ALL.uniq.size
+  end
+
+  def test_reasons_are_single_short_lines
+    ALL.each do |reason|
+      refute_empty reason.strip
+      refute_includes reason, "\n"
+      assert_operator reason.length, :<=, 70
+    end
+  end
+
+  def test_there_is_more_than_one_reason_to_leave
+    assert_operator ALL.size, :>, 5
+  end
+end

--- a/test/skyline_test.rb
+++ b/test/skyline_test.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class SkylineTest < Minitest::Test
+  LINES = Vergissberlin::Skyline::LINES
+
+  def test_lines_share_one_width
+    widths = LINES.map(&:length)
+
+    assert_equal 1, widths.uniq.size, 'skyline lines must share one width'
+    assert_equal Vergissberlin::Skyline::WIDTH, widths.first
+    assert_operator widths.first, :>=, 60
+  end
+
+  def test_lines_are_pure_ascii
+    LINES.each do |line|
+      assert(line.ascii_only?, "not ascii: #{line}")
+    end
+  end
+
+  def test_fernsehturm_sphere_is_centered_below_the_antenna
+    antenna = LINES.first.index('|')
+    sphere = LINES.find { |line| line.include?('#####') }
+
+    refute_nil sphere, 'skyline must show the Fernsehturm sphere'
+    assert_equal antenna, sphere.index('#####') + 2
+  end
+
+  def test_tower_shaft_sits_on_the_ground_line
+    assert_equal LINES.last.length, LINES.last.count('_|')
+  end
+end


### PR DESCRIPTION
## What

The default output of `vergissberlin` no longer prints the figlet `THATS COOL`
banner. It now draws an ASCII art skyline of Berlin with the Fernsehturm at its
center and prints a randomly picked German reason for wanting to forget the city
below it.

```
                              |
                              |
                              |
                             /|\
                           .-----.
                          / ..... \
                         |  #####  |
                          \ ..... /
                           '-----'
                             | |
                             | |
                             | |
               _             | |
             .' '.           | |            _____
      __    /_____\          | |           |     |     __
     |  |   |     |  ___    /   \   ___    | [ ] |    |  |
  ___|[]|___|  [] |_|   |__/     \_|   |___|     |____|[]|___
 |   |  |   |     | | []|  |     | | []|   | [ ] |    |  |   |
 |[] |  |___|  [] |_| []|__|  [] |_| []|___|     |____|[]| [] |
_|___|__|___|_____|_|___|__|_____|_|___|___|_____|____|__|____|_

  Ein Grund, Berlin zu vergessen:
  In der U8 riecht es nach warmem Bier und alten Fehlern.
```

## How

- **`lib/vergissberlin/skyline.rb`** (new) — `Vergissberlin::Skyline` holds the
  raw art and normalizes every line to a single `WIDTH` via `ljust`. Padding is
  computed instead of hand-counted, so the diagonal rainbow gradient stays even
  and the art cannot drift out of alignment. Pure ASCII, no box-drawing
  characters, so it renders in any terminal.
- **`lib/vergissberlin/reasons.rb`** (new) — `Vergissberlin::Reasons` with 16
  reasons and `Reasons.sample(random:)`. The reasons stay German on purpose (the
  gem name is a German joke); code, comments and docs remain English per
  `AGENTS.md`.
- **`lib/vergissberlin/cli.rb`** — `render_banner` became `render_skyline` plus
  `render_reason`; the `BANNER`/`BANNER_LINES` constants are gone. `CLI.run` and
  `CLI#initialize` accept a `random:` keyword (default `Random.new`) so tests can
  assert reproducible output without stubbing globals.

The reason line is deliberately printed uncolored — the rainbow is a background-
independent effect on line art, but low-contrast body text is a readability
problem on light terminals.

## Compatibility

- `--help`, `--version` / `-v`, exit codes and the invalid-option path are
  unchanged.
- `NO_COLOR`, `FORCE_COLOR`, `CLICOLOR_FORCE` and TTY detection behave as before.
- The `Vergissberlin::CLI::BANNER` and `BANNER_LINES` constants were removed.
  They were internal rendering details, never documented as public API.

## Tests

`30 runs, 212 assertions, 0 failures, 0 errors` — line and branch coverage at
100%.

- `test/skyline_test.rb` (new): uniform line width, ASCII-only, sphere centered
  under the antenna, closed ground line.
- `test/reasons_test.rb` (new): sampling returns a known reason, seeded sampling
  is reproducible, reasons are unique and single short lines.
- `test/cli_test.rb`: banner assertions replaced by skyline/reason assertions,
  plus seeded reproducibility and seed-variance cases.
- `test/bin_cli_test.rb`: end-to-end assertion updated to the new output.

## Docs

- `README.md`: usage block and color section describe the new output.
- `AGENTS.md`: layout table lists the two new files.


---
_Generated by [Claude Code](https://claude.ai/code/session_015akWaXo7USQmaRP4v92y3D)_